### PR TITLE
Fix: 10.0.7 error - now it first checks if frame.healthBar exists before coloring it

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -535,7 +535,7 @@ function rs.SetBarColor(frame)
             r, g, b =  frame.healthBar.r, frame.healthBar.g, frame.healthBar.b
         end
 
-        -- FIX FOR 10.7 - Check if frame.healthBar exists before trying to color it
+        -- FIX FOR 10.0.7 - Check if frame.healthBar exists before trying to color it
         if (frame.healthBar) then 
             frame.healthBar:SetStatusBarColor(r, g, b);
         end

--- a/Core.lua
+++ b/Core.lua
@@ -535,7 +535,10 @@ function rs.SetBarColor(frame)
             r, g, b =  frame.healthBar.r, frame.healthBar.g, frame.healthBar.b
         end
 
-        frame.healthBar:SetStatusBarColor(r, g, b);
+        -- FIX FOR 10.7 - Check if frame.healthBar exists before trying to color it
+        if (frame.healthBar) then 
+            frame.healthBar:SetStatusBarColor(r, g, b);
+        end
 
         if (frame.optionTable.colorHealthWithExtendedColors) then
             frame.selectionHighlight:SetVertexColor(r, g, b);

--- a/RSPlates.toc
+++ b/RSPlates.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 100007
 ## Title: |cff00FF7FRS|rPlates
 ## Author: Flyover-埃德萨拉
 # (Thanks for the localization part of EK)


### PR DESCRIPTION
This should fix the issue people are running into when using the addon in Dragonflight patch 10.0.7.

Also bumped TOC to 10.0.7