### PR TITLE
Fix: 10.0.7 rs.SetBarColor error

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -535,7 +535,7 @@ function rs.SetBarColor(frame)
             r, g, b =  frame.healthBar.r, frame.healthBar.g, frame.healthBar.b
         end
 
-        -- FIX FOR 10.7 - Check if frame.healthBar exists before trying to color it
+        -- FIX FOR 10.0.7 - Check if frame.healthBar exists before trying to color it
         if (frame.healthBar) then 
             frame.healthBar:SetStatusBarColor(r, g, b);
         end

--- a/Core.lua
+++ b/Core.lua
@@ -535,7 +535,10 @@ function rs.SetBarColor(frame)
             r, g, b =  frame.healthBar.r, frame.healthBar.g, frame.healthBar.b
         end
 
-        frame.healthBar:SetStatusBarColor(r, g, b);
+        -- FIX FOR 10.7 - Check if frame.healthBar exists before trying to color it
+        if (frame.healthBar) then 
+            frame.healthBar:SetStatusBarColor(r, g, b);
+        end
 
         if (frame.optionTable.colorHealthWithExtendedColors) then
             frame.selectionHighlight:SetVertexColor(r, g, b);

--- a/Core.lua
+++ b/Core.lua
@@ -534,11 +534,9 @@ function rs.SetBarColor(frame)
         if not r then
             r, g, b =  frame.healthBar.r, frame.healthBar.g, frame.healthBar.b
         end
-
-        -- FIX FOR 10.0.7 - Check if frame.healthBar exists before trying to color it
-        if (frame.healthBar) then 
-            frame.healthBar:SetStatusBarColor(r, g, b);
-        end
+   
+        -- FIX FOR 10.0.7 - Prevents the addon for spitting errors when refreshing frames
+        frame.healthBar:SetStatusBarColor(r or 1, g or 1, b or 1);
 
         if (frame.optionTable.colorHealthWithExtendedColors) then
             frame.selectionHighlight:SetVertexColor(r, g, b);

--- a/RSPlates.toc
+++ b/RSPlates.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 100007
 ## Title: |cff00FF7FRS|rPlates
 ## Author: Flyover-埃德萨拉
 # (Thanks for the localization part of EK)


### PR DESCRIPTION
Core.lua: line 538

From this:
`frame.healthBar:SetStatusBarColor(r, g, b);`

To this:
`frame.healthBar:SetStatusBarColor(r or 1, g or 1, b or 1);`

Should fix the issue for good.
